### PR TITLE
Wrapper around `oc` for using with Python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTEST_OPTIONS = -vvv
+PYTEST_OPTIONS = -v
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
@@ -28,14 +28,14 @@ lint:
 	pipenv run flake8 conduitqe tests
 
 test:
-	pipenv run py.test tests
+	pipenv run pytest tests
 
 test-api:
-	pipenv run py.test $(PYTEST_OPTIONS) conduitqe/tests/api/
+	pipenv run pytest $(PYTEST_OPTIONS) conduitqe/tests/api/
 
 
 test-coverage:
-	pipenv run py.test --verbose --cov-report term --cov=conduitqe --cov=tests tests
+	pipenv run pytest --verbose --cov-report term --cov=conduitqe --cov=tests tests
 
 clean:
 	find . -type f -name "*.py[co]" -delete

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 [packages]
 pytest = "*"
 requests = "*"
+pexpect = "*"
 conduitqe = {editable = true,path = "."}
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9c44ae763f6eaae1478e2b8a7d67dc167df7e4c1812a619524b346c567297ec8"
+            "sha256": "39f5419a9f9eb38b9709d4621a964750d1b7e762dbb0432b92e6b8e1d5ac9934"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -64,11 +64,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
-                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
+                "sha256:3ad685ff8512bf6dc5a8b82ebf73543999b657eded8c11803d9ba6b648986f4d",
+                "sha256:8bb43d1f51ecef60d81854af61a3a880555a14643691cc4b64a6ee269c78f09a"
             ],
             "markers": "python_version > '2.7'",
-            "version": "==7.0.0"
+            "version": "==7.1.0"
         },
         "packaging": {
             "hashes": [
@@ -77,12 +77,27 @@
             ],
             "version": "==19.0"
         },
+        "pexpect": {
+            "hashes": [
+                "sha256:2094eefdfcf37a1fdbfb9aa090862c1a4878e5c7e0e7e7088bdb511c558e5cd1",
+                "sha256:9e2c1fd0e6ee3a49b28f95d4b33bc389c89b20af6a1255906e90ff1262ce62eb"
+            ],
+            "index": "pypi",
+            "version": "==4.7.0"
+        },
         "pluggy": {
             "hashes": [
                 "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
                 "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
             ],
             "version": "==0.12.0"
+        },
+        "ptyprocess": {
+            "hashes": [
+                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0",
+                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
+            ],
+            "version": "==0.6.0"
         },
         "py": {
             "hashes": [
@@ -225,11 +240,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
-                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
+                "sha256:3ad685ff8512bf6dc5a8b82ebf73543999b657eded8c11803d9ba6b648986f4d",
+                "sha256:8bb43d1f51ecef60d81854af61a3a880555a14643691cc4b64a6ee269c78f09a"
             ],
             "markers": "python_version > '2.7'",
-            "version": "==7.0.0"
+            "version": "==7.1.0"
         },
         "packaging": {
             "hashes": [

--- a/conduitqe/oc.py
+++ b/conduitqe/oc.py
@@ -1,0 +1,79 @@
+"""OpenShift CLI (oc) wrapper."""
+
+import logging
+import pexpect
+
+OPENSHIFT_URL = 'https://api.insights-dev.openshift.com'
+
+logger = logging.getLogger(__name__)
+
+
+def oc(params):
+    "Run oc with params. May raise 'RuntimeError' on error."
+    cmd = f'oc {params}'
+    logger.debug(cmd)
+    output = pexpect.run(cmd).decode('utf-8')
+    if output.startswith('error:') or output.startswith('Error:'):
+        raise RuntimeError(output)
+    return output
+
+
+def parse(output):
+    "Parse (normalize) output and return a list of lines."
+    output = output.split('\r\n')
+    output = [line for line in output if line]
+    return output
+
+
+def login(token):
+    "Log in with Bearer token."
+    cmd = f'login {OPENSHIFT_URL} --token={token}'
+    return parse(oc(cmd))
+
+
+def logout():
+    "Log out from OpenShift."
+    cmd = 'logout'
+    return parse(oc(cmd))
+
+
+def get_projects():
+    "Get all projects."
+    cmd = 'projects'
+    return parse(oc(cmd))
+
+
+def get_project():
+    "Get current project."
+    cmd = 'project'
+    return parse(oc(cmd))
+
+
+def set_project(name):
+    "Select project by name."
+    cmd = f'project {name}'
+    return parse(oc(cmd))
+
+
+def get_pods():
+    "Get all pods."
+    cmd = 'get pods'
+    return parse(oc(cmd))
+
+
+def logs(pod):
+    "Get logs from pod."
+    cmd = f'logs {pod}'
+    return parse(oc(cmd))
+
+
+def exec(pod, command):
+    "Execute command in a pod."
+    cmd = f'exec {pod} {command}'
+    return parse(oc(cmd))
+
+
+def rsh(pod, command):
+    "Open remote shell on pod and execute command in a pod."
+    cmd = f'rsh {pod} {command}'
+    return parse(oc(cmd))


### PR DESCRIPTION
The purpose of this module is to allows us to use `oc` on our test framework, in order to substitute the functionality of `scripts/conduit-qe-utils.sh`. How to use it?

```python
>>> from conduitqe import oc
>>> oc.login('...LHgVpuHdAh3x11q...') # token from copying login command on OpenShift
>>> oc.set_project('rhsm-ci') # set current project to rshm-ci
>>> oc.get_pods() # list all pods
>>> oc.exec('rhsm-conduit-256-lv8xm', 'uptime') # execute command uptime
[' 16:06:56 up 21:37,  0 users,  load average: 0.17, 0.27, 0.35']
```