### PR TITLE
Add initial tests for testing facts updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
                     git 'https://github.com/peaqe/conduit-qe'
                     sh 'sudo dnf install -y pipenv'
                     sh 'pipenv install'
-                    sh 'pipenv run py.test -v conduitqe/tests/api/'
+                    sh 'pipenv run pytest -v -m "not openshift" conduitqe/tests/api/'
                 }
             }
         }

--- a/conduitqe/config.py
+++ b/conduitqe/config.py
@@ -10,6 +10,8 @@ CONDUIT_BASE_URL = 'http://localhost:8080'
 INVENTORY_CI_BASE_URL = 'http://insights-inventory.platform-ci.svc:8080'
 INVENTORY_QA_BASE_URL = 'http://insights-inventory.platform-qa.svc:8080'
 INVENTORY_BASE_URL = INVENTORY_QA_BASE_URL
+ENDPOINT_GET_FACTS = '/api/inventory/v1/hosts'
+ENDPOINT_TRIGGER_UPDATE = '/r/insights/platform/rhsm-conduit/v1/inventories'
 
 ConfigNamespace = None
 logger = logging.getLogger(__name__)
@@ -46,6 +48,10 @@ def get_config():
         ConfigNamespace = SimpleNamespace(**kwargs)
         ConfigNamespace.conduit_base_url = get_conduit_base_url()
         ConfigNamespace.inventory_base_url = get_inventory_base_url()
+        ConfigNamespace.endpoint_get_facts = os.getenv(
+            'ENDPOINT_GET_FACTS', ENDPOINT_GET_FACTS)
+        ConfigNamespace.endpoint_trigger_update = os.getenv(
+            'ENDPOINT_TRIGGER_UPDATE', ENDPOINT_TRIGGER_UPDATE)
     return ConfigNamespace
 
 

--- a/conduitqe/tests/api/test_facts.py
+++ b/conduitqe/tests/api/test_facts.py
@@ -1,0 +1,97 @@
+"""Tests for triggering facts updates.
+
+:caseautomation: automated
+:casecomponent: api
+:caseimportance: high
+:caselevel: integration
+:requirement: rhsm-conduit
+:testtype: functional
+:upstream: yes
+"""
+
+import logging
+import json
+import time
+import pytest
+import oc
+
+from conduitqe.config import get_config
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def rhsm_conduit_instance():
+    cfg = get_config()
+    return cfg.pod
+
+
+@pytest.fixture(scope="module")
+def config():
+    cfg = get_config()
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def openshift_setup():
+    cfg = get_config()
+    oc.login(cfg.openshift_url, cfg.openshift_token)
+    result = oc.set_project(cfg.project)
+    return result
+
+
+@pytest.mark.openshift
+def test_conduit_is_running(openshift_setup, rhsm_conduit_instance):
+    """Test if a given conduit instance is up and running.
+
+    :id: b082bdae-aca5-11e9-ab30-acde4800112
+    :description: Ensure that a given conduit instance is up and running.
+    :expectedresults: Running the command `uptime` returns the system is up
+        (it doesn't matter for how long).
+    """
+    output = oc.exec(rhsm_conduit_instance, 'uptime')
+    assert ' up ' in output[0]
+
+
+def lookup_in_logs(logs, text, org_key):
+    """Look up text in logs for matching org_key.
+    """
+    match = False
+    for log in logs:
+        data = json.loads(log)
+        message = data.get('message', '')
+        logger.debug("message '%s' with text '%s' and org_key '%s'",
+                     message, text, org_key)
+        if message and message.startswith(text):
+            if org_key in data['message']:
+                match = True
+                break
+    return match
+
+
+@pytest.mark.openshift
+def test_trigger_inventory_update(config, rhsm_conduit_instance):
+    """Test triggering simple inventory update.
+    :id: 4e92aafa-aca8-11e9-b0e7-acde48001122
+    :description: Test that triggering a simple inventory update, without
+        changing any machine's facts, should result in success.
+    :expectedresults: inspecting the conduit logs should indicate that
+        the org key is presented and the system was successfully updated.
+    """
+    org_key = config.org_id
+    endpoint = f'/r/insights/platform/rhsm-conduit/v1/inventories/{org_key}'
+    url = f'{config.conduit_base_url}{endpoint}'
+    cmd = f'curl -s -I -X POST {url}'
+    output = oc.exec(rhsm_conduit_instance, cmd)
+    assert output[0].startswith('HTTP/1.1 204'), '\n'.join(output)
+    # Updating inventory look-up
+    logs = oc.logs(rhsm_conduit_instance, since='1m')
+    updating = lookup_in_logs(logs, 'Updating inventory', org_key)
+    assert updating, f'Updating inventory has failed for org key {org_key}'
+    time.sleep(5)
+    # Host inventory update completed look-up
+    logs = oc.logs(rhsm_conduit_instance, since='1m')
+    updated = lookup_in_logs(logs, 'Host inventory update completed', org_key)
+    assert updated, \
+        f'Host inventory update not completed for org key {org_key}'

--- a/conduitqe/tests/api/test_facts.py
+++ b/conduitqe/tests/api/test_facts.py
@@ -55,7 +55,6 @@ def test_conduit_is_running(openshift_setup, rhsm_conduit_instance):
 def lookup_in_logs(logs, text, org_key):
     """Look up text in logs for matching org_key.
     """
-    match = False
     for log in logs:
         data = json.loads(log)
         message = data.get('message', '')
@@ -63,9 +62,8 @@ def lookup_in_logs(logs, text, org_key):
                      message, text, org_key)
         if message and message.startswith(text):
             if org_key in data['message']:
-                match = True
-                break
-    return match
+                return True
+    return False
 
 
 @pytest.mark.openshift

--- a/conduitqe/tests/api/test_facts.py
+++ b/conduitqe/tests/api/test_facts.py
@@ -77,8 +77,8 @@ def test_trigger_inventory_update(config, rhsm_conduit_instance):
         the org key is presented and the system was successfully updated.
     """
     org_key = config.org_id
-    endpoint = f'/r/insights/platform/rhsm-conduit/v1/inventories/{org_key}'
-    url = f'{config.conduit_base_url}{endpoint}'
+    endpoint_trigger_update = f'{config.endpoint_trigger_update}/{org_key}'
+    url = f'{config.conduit_base_url}{endpoint_trigger_update}'
     cmd = f'curl -s -I -X POST {url}'
     output = oc.exec(rhsm_conduit_instance, cmd)
     assert output[0].startswith('HTTP/1.1 204'), '\n'.join(output)
@@ -104,8 +104,7 @@ def test_check_basic_facts(config, rhsm_conduit_instance):
         where we have basic facts for the hosts that belongs to an account.
     """
     auth = create_authentication(config.account_number)
-    endpoint = '/api/inventory/v1/hosts'
-    url = f'{config.inventory_base_url}{endpoint}'
+    url = f'{config.inventory_base_url}{config.endpoint_get_facts}'
     header = f'x-rh-identity: {auth}'
     cmd = f'curl -s -H "{header}" {url}'
     output = oc.exec(rhsm_conduit_instance, cmd)

--- a/conduitqe/tests/api/test_facts.py
+++ b/conduitqe/tests/api/test_facts.py
@@ -22,22 +22,20 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
-def rhsm_conduit_instance():
-    cfg = get_config()
-    return cfg.pod
-
-
-@pytest.fixture(scope="module")
 def config():
     cfg = get_config()
     return cfg
 
 
 @pytest.fixture(scope="module")
-def openshift_setup():
-    cfg = get_config()
-    oc.login(cfg.openshift_url, cfg.openshift_token)
-    result = oc.set_project(cfg.project)
+def rhsm_conduit_instance(config):
+    return config.conduit_pod
+
+
+@pytest.fixture(scope="module")
+def openshift_setup(config):
+    oc.login(config.openshift_url, config.openshift_token)
+    result = oc.set_project(config.project)
     return result
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+	local: marks tests for running locally
+	openshift: marks tests for running on Openshift

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+addopts = --strict-markers
 markers =
 	local: marks tests for running locally
 	openshift: marks tests for running on Openshift


### PR DESCRIPTION
Add tests for triggering facts updates [ in progress ].

Configuration: we need to login on Openshift, so set in `~/.conduitqe.conf` or export  the following  environment variables:
* `OPENSHIFT_URL=https://api.insights-dev.openshift.com`
* `OPENSHIFT_TOKEN=...azw`
* `PROJECT=rhsm-ci`
* `CONDUIT_POD=rhsm-conduit-274-lh49n` (the instance of a running rhsm-conduit -- needs to automatically guess it?).
* `ORG_ID=13369709` (your org key/id).

Running the tests:

```
$ pytest -v conduitqe/tests/api/test_facts.py  
...
conduitqe/tests/api/test_facts.py::test_conduit_is_running PASSED        [ 50%]
conduitqe/tests/api/test_facts.py::test_trigger_inventory_update PASSED  [100%]
...
```